### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,5 @@ Feedstock Maintainers
 =====================
 
 * [@faymanns](https://github.com/faymanns/)
-* [@goanpeca](https://github.com/goanpeca/)
 * [@jaimergp](https://github.com/jaimergp/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,5 +54,4 @@ about:
 extra:
   recipe-maintainers:
     - faymanns
-    - goanpeca
     - jaimergp


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #4